### PR TITLE
Add kinnosuke-clocking-cli path and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ bitbar-kinnosuke-cli
 ## Pre-requirement
 
 [`kinnosuke-clocking-cli`](https://github.com/yano3/kinnosuke-clocking-cli/) version equal to or after `0.2.0`.
+Please put kinnosuke-clocking-cli to `/usr/local/bin`.
 
 ## Install
 
@@ -13,7 +14,7 @@ Put `kin.10s.sh` to your bitbar plugin directory.
 
 ## Config
 
-Please put `~/.kinnosuke` to youe $HOME:
+Please put `~/.kinnosuke` to your $HOME:
 
 ```bash
 export KINNOSUKE_COMPANYCD="foobar"


### PR DESCRIPTION
Add kinnosuke-clocking-cli path to pre-requirement and fix typo in README.md.